### PR TITLE
修正　プール運用編　プール廃止処理　「cd $NODE_HOMEの追加」

### DIFF
--- a/docs/operation/pool-retire.md
+++ b/docs/operation/pool-retire.md
@@ -61,6 +61,7 @@
 
 === "エアギャップオフラインマシン"
     ```bash
+    cd $NODE_HOME
     chmod u+rwx $HOME/cold-keys
     cardano-cli stake-pool deregistration-certificate \
     --cold-verification-key-file $HOME/cold-keys/node.vkey \


### PR DESCRIPTION
https://docs.spojapanguild.net/operation/pool-retire/
プール廃止処理
1.リタイア処理

エアギャップで行う２つ目のコマンドである、
トランザクションに署名する
```
cardano-cli transaction sign \
    --tx-body-file tx.raw \
    --signing-key-file payment.skey \
    --signing-key-file $HOME/cold-keys/node.skey \
    $NODE_NETWORK \
    --out-file tx.signed
```

上記が、$NODE_HOME上で行うコマンドとなっているので、
エアギャップで行う一つ目のコマンド
```
chmod u+rwx $HOME/cold-keys
cardano-cli stake-pool deregistration-certificate \
--cold-verification-key-file $HOME/cold-keys/node.vkey \
--epoch *** \
--out-file pool.dereg
```
の最初に、
```
cd $NODE_HOME
```
を追加しました。