### PR TITLE
プール構築マニュアルの修正

### DIFF
--- a/docs/setup/6-register-stakeaddress.md
+++ b/docs/setup/6-register-stakeaddress.md
@@ -94,7 +94,7 @@ keyDepositの値を出力します。
     fee=$(cardano-cli conway transaction calculate-min-fee \
         --tx-body-file tx.tmp \
         --witness-count 2 \
-        --protocol-params-file params.json | awk '{ print $1 }')
+        --protocol-params-file params.json | jq '.fee')
     echo fee: $fee
     ```
 


### PR DESCRIPTION
ステークアドレスの登録で、現在の最低手数料を取得するコマンドが実行出来なくなっていたため修正しました。